### PR TITLE
Always return an object when loading a YAML file

### DIFF
--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -4,7 +4,8 @@ import equals from 'fast-deep-equal/es6';
 
 function read(file: string): KeyValue {
     try {
-        return yaml.load(fs.readFileSync(file, 'utf8'));
+        const result = yaml.load(fs.readFileSync(file, 'utf8'));
+        return result as KeyValue ?? {};
     } catch (error) {
         if (error.name === 'YAMLException') {
             error.file = file;


### PR DESCRIPTION
If loading an empty file or a file that only contains comments, `yaml.load()` return null, which is the cause for #20283. This PR should make loading of YAML file more robust, as I don't think anybody relies on the special behaviour of getting a null for an empty file.